### PR TITLE
multiple fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,6 +69,7 @@ jobs:
         version: 6.2.2
         py7zrversion: ' '
         aqtversion: ' '
+        setup-python: false
 
     - name: run-vcpkg
       uses: lukka/run-vcpkg@v7.3

--- a/src/models/SettingsModels.hpp
+++ b/src/models/SettingsModels.hpp
@@ -93,7 +93,10 @@ namespace Qv2ray::Models
         {
             ProtocolInboundBase::Propagate(in);
             in.inboundSettings.protocolSettings[u"udp"_qs] = *EnableUDP;
-            in.inboundSettings.protocolSettings[u"ip"_qs] = *UDPLocalAddress;
+            if (!UDPLocalAddress->isEmpty())
+            {
+                in.inboundSettings.protocolSettings[u"ip"_qs] = *UDPLocalAddress;
+            }
         }
     };
 

--- a/src/plugins/PluginsCommon/V2RayModels.hpp
+++ b/src/plugins/PluginsCommon/V2RayModels.hpp
@@ -82,17 +82,10 @@ namespace Qv2ray::Models
 
     struct V2RayFakeDNSObject
     {
-        struct PoolObject
-        {
-            Bindable<QString> ipPool;
-            Bindable<int> poolSize;
-            QJS_COMPARE(PoolObject, ipPool, poolSize)
-            QJS_JSON(F(ipPool, poolSize))
-        };
-
-        Bindable<QList<PoolObject>> pools;
-        QJS_JSON(P(pools))
-        QJS_COMPARE(V2RayFakeDNSObject, pools)
+        Bindable<QString> ipPool;
+        Bindable<int> poolSize;
+        QJS_COMPARE(V2RayFakeDNSObject, ipPool, poolSize)
+        QJS_JSON(F(ipPool, poolSize))
         static auto fromJson(const QJsonObject &o)
         {
             V2RayFakeDNSObject dns;

--- a/src/plugins/protocols/core/OutboundHandler.cpp
+++ b/src/plugins/protocols/core/OutboundHandler.cpp
@@ -183,7 +183,7 @@ QString SerializeTrojan(const QString &name, const IOConnectionSettings &connect
     url.setScheme(u"trojan"_qs);
     url.setHost(connection.address);
     url.setPort(connection.port.from);
-    url.setUserInfo(connection.protocolSettings[u"password"_qs].toString());
+    url.setUserName(connection.protocolSettings[u"password"_qs].toString().toUtf8(), QUrl::DecodedMode);
 
     Qv2ray::Models::StreamSettingsObject stream;
     stream.loadJson(connection.streamSettings);
@@ -195,7 +195,7 @@ QString SerializeTrojan(const QString &name, const IOConnectionSettings &connect
     }
 
     url.setFragment(name);
-    return url.toString();
+    return url.toString(QUrl::ComponentFormattingOption::FullyEncoded);
 }
 
 std::optional<std::pair<QString, IOConnectionSettings>> DeserializeTrojan(const QString &link)
@@ -205,7 +205,7 @@ std::optional<std::pair<QString, IOConnectionSettings>> DeserializeTrojan(const 
     conn.address = url.host();
     conn.port = url.port();
     conn.protocol = u"trojan"_qs;
-    conn.protocolSettings.insert(u"password"_qs, url.userInfo());
+    conn.protocolSettings.insert(u"password"_qs, QUrl::fromPercentEncoding(url.userInfo().toUtf8()));
 
     QUrlQuery q{ url.query() };
     if (q.hasQueryItem(u"sni"_qs))

--- a/src/plugins/protocols/ui/outbound/shadowsocks.cpp
+++ b/src/plugins/protocols/ui/outbound/shadowsocks.cpp
@@ -4,6 +4,8 @@ ShadowsocksOutboundEditor::ShadowsocksOutboundEditor(QWidget *parent) : Qv2rayPl
 {
     setupUi(this);
     setProperty("QV2RAY_INTERNAL_HAS_STREAMSETTINGS", true);
+    shadowsocks.method.ReadWriteBind(ss_encryptionMethod, "currentText", &QComboBox::currentTextChanged);
+    shadowsocks.password.ReadWriteBind(ss_passwordTxt, "text", &QLineEdit::textEdited);
 }
 
 void ShadowsocksOutboundEditor::changeEvent(QEvent *e)

--- a/src/plugins/protocols/ui/outbound/shadowsocks.hpp
+++ b/src/plugins/protocols/ui/outbound/shadowsocks.hpp
@@ -16,8 +16,6 @@ class ShadowsocksOutboundEditor
     void Load() override
     {
         shadowsocks.loadJson(settings);
-        shadowsocks.method.ReadWriteBind(ss_encryptionMethod, "currentText", &QComboBox::currentTextChanged);
-        shadowsocks.password.ReadWriteBind(ss_passwordTxt, "text", &QLineEdit::textEdited);
     }
 
     void Store() override

--- a/src/plugins/v2ray/core/V2Ray/ProfileGenerator.cpp
+++ b/src/plugins/v2ray/core/V2Ray/ProfileGenerator.cpp
@@ -139,8 +139,8 @@ QByteArray V2RayProfileGenerator::Generate()
     if (!profile.routing.dns.isEmpty())
         rootconf[u"dns"_qs] = profile.routing.dns;
 
-    if (!profile.routing.fakedns.isEmpty())
-        rootconf[u"fakedns"_qs] = profile.routing.fakedns;
+    if (!profile.routing.fakedns[u"pools"_qs].toArray().isEmpty())
+        rootconf[u"fakedns"_qs] = profile.routing.fakedns[u"pools"_qs];
 
     OutboundMarkSettingFilter(rootconf, settings.OutboundMark);
 

--- a/src/plugins/v2ray/core/V2Ray5/Kernel.cpp
+++ b/src/plugins/v2ray/core/V2Ray5/Kernel.cpp
@@ -142,7 +142,7 @@ std::optional<QString> V2Ray5Kernel::ValidateConfig(const QString &path)
         process.setProcessEnvironment(env);
         process.setProcessChannelMode(QProcess::MergedChannels);
         V2RayCorePluginClass::Log(u"Starting V2Ray core with test options"_qs);
-        process.start(settings.CorePath, { u"-test"_qs, u"-config"_qs, path }, QIODevice::ReadWrite | QIODevice::Text);
+        process.start(settings.CorePath, { u"test"_qs, u"-config"_qs, path }, QIODevice::ReadWrite | QIODevice::Text);
         process.waitForFinished();
 
         if (process.exitCode() != 0)

--- a/src/plugins/v2ray/core/V2Ray5/ProfileGenerator.cpp
+++ b/src/plugins/v2ray/core/V2Ray5/ProfileGenerator.cpp
@@ -139,8 +139,8 @@ QByteArray V2Ray5ProfileGenerator::Generate()
     if (!profile.routing.dns.isEmpty())
         rootconf[u"dns"_qs] = profile.routing.dns;
 
-    if (!profile.routing.fakedns.isEmpty())
-        rootconf[u"fakedns"_qs] = profile.routing.fakedns;
+    if (!profile.routing.fakedns[u"pools"_qs].toArray().isEmpty())
+        rootconf[u"fakedns"_qs] = profile.routing.fakedns[u"pools"_qs];
 
     OutboundMarkSettingFilter(rootconf, settings.OutboundMark);
 

--- a/src/plugins/v2ray/core/V2RayGo/ProfileGenerator.cpp
+++ b/src/plugins/v2ray/core/V2RayGo/ProfileGenerator.cpp
@@ -139,8 +139,8 @@ QByteArray V2RayGoProfileGenerator::Generate()
     if (!profile.routing.dns.isEmpty())
         rootconf[u"dns"_qs] = profile.routing.dns;
 
-    if (!profile.routing.fakedns.isEmpty())
-        rootconf[u"fakedns"_qs] = profile.routing.fakedns;
+    if (!profile.routing.fakedns[u"pools"_qs].toArray().isEmpty())
+        rootconf[u"fakedns"_qs] = profile.routing.fakedns[u"pools"_qs];
 
     OutboundMarkSettingFilter(rootconf, settings.OutboundMark);
 

--- a/src/ui/widgets/editors/DnsSettingsWidget.cpp
+++ b/src/ui/widgets/editors/DnsSettingsWidget.cpp
@@ -64,7 +64,7 @@ QvMessageBusSlotImpl(DnsSettingsWidget)
     }
 }
 
-void DnsSettingsWidget::SetDNSObject(const Qv2ray::Models::V2RayDNSObject &_dns, const Qv2ray::Models::V2RayFakeDNSObject &_fakeDNS)
+void DnsSettingsWidget::SetDNSObject(const Qv2ray::Models::V2RayDNSObject &_dns, const QList<Qv2ray::Models::V2RayFakeDNSObject> &_fakeDNS)
 {
     this->dns = _dns;
 
@@ -95,14 +95,14 @@ void DnsSettingsWidget::SetDNSObject(const Qv2ray::Models::V2RayDNSObject &_dns,
     dnsDisableCacheCB->setChecked(dns.disableCache);
 
     // WARNING TODO: BAD HACK need list model
-    if (!_fakeDNS.pools->isEmpty())
+    if (!_fakeDNS.isEmpty())
     {
-        fakeDNSIPPool->setCurrentText(_fakeDNS.pools->first().ipPool);
-        fakeDNSIPPoolSize->setValue(_fakeDNS.pools->first().poolSize);
-        if (_fakeDNS.pools->size() > 1)
+        fakeDNSIPPool->setCurrentText(_fakeDNS.first().ipPool);
+        fakeDNSIPPoolSize->setValue(_fakeDNS.first().poolSize);
+        if (_fakeDNS.size() > 1)
         {
-            fakeDNSIPv6Pool->setCurrentText(_fakeDNS.pools->at(1).ipPool);
-            fakeDNSIPv6PoolSize->setValue(_fakeDNS.pools->at(1).poolSize);
+            fakeDNSIPv6Pool->setCurrentText(_fakeDNS.at(1).ipPool);
+            fakeDNSIPv6PoolSize->setValue(_fakeDNS.at(1).poolSize);
         }
     }
     UPDATE_UI_ENABLED_STATE
@@ -150,7 +150,7 @@ void DnsSettingsWidget::ShowCurrentDnsServerDetails()
     ProcessDnsPortEnabledState();
 }
 
-std::pair<Qv2ray::Models::V2RayDNSObject, Qv2ray::Models::V2RayFakeDNSObject> DnsSettingsWidget::GetDNSObject()
+std::pair<Qv2ray::Models::V2RayDNSObject, QList<Qv2ray::Models::V2RayFakeDNSObject>> DnsSettingsWidget::GetDNSObject()
 {
     dns.hosts.clear();
     for (auto i = 0; i < staticResolvedDomainsTable->rowCount(); i++)
@@ -161,11 +161,11 @@ std::pair<Qv2ray::Models::V2RayDNSObject, Qv2ray::Models::V2RayFakeDNSObject> Dn
             dns.hosts.insert(item1->text(), item2->text());
     }
 
-    Qv2ray::Models::V2RayFakeDNSObject fakeDNS;
+    QList<Qv2ray::Models::V2RayFakeDNSObject> fakeDNS;
     if (!fakeDNSIPPool->currentText().isEmpty())
-        fakeDNS.pools->append(V2RayFakeDNSObject::PoolObject{ { fakeDNSIPPool->currentText() }, fakeDNSIPPoolSize->value() });
+        fakeDNS.append(V2RayFakeDNSObject{ { fakeDNSIPPool->currentText() }, fakeDNSIPPoolSize->value() });
     if (!fakeDNSIPv6Pool->currentText().isEmpty())
-        fakeDNS.pools->append(V2RayFakeDNSObject::PoolObject{ { fakeDNSIPv6Pool->currentText() }, fakeDNSIPv6PoolSize->value() });
+        fakeDNS.append(V2RayFakeDNSObject{ { fakeDNSIPv6Pool->currentText() }, fakeDNSIPv6PoolSize->value() });
     return { dns, fakeDNS };
 }
 

--- a/src/ui/widgets/editors/DnsSettingsWidget.hpp
+++ b/src/ui/widgets/editors/DnsSettingsWidget.hpp
@@ -17,8 +17,8 @@ class DnsSettingsWidget
 
   public:
     explicit DnsSettingsWidget(QWidget *parent = nullptr);
-    void SetDNSObject(const Qv2ray::Models::V2RayDNSObject &dns, const Qv2ray::Models::V2RayFakeDNSObject &fakeDNS);
-    std::pair<Qv2ray::Models::V2RayDNSObject, Qv2ray::Models::V2RayFakeDNSObject> GetDNSObject();
+    void SetDNSObject(const Qv2ray::Models::V2RayDNSObject &dns, const QList<Qv2ray::Models::V2RayFakeDNSObject> &fakeDNS);
+    std::pair<Qv2ray::Models::V2RayDNSObject, QList<Qv2ray::Models::V2RayFakeDNSObject>> GetDNSObject();
     bool CheckIsValidDNS() const;
 
   private slots:

--- a/src/ui/windows/w_PreferencesWindow.cpp
+++ b/src/ui/windows/w_PreferencesWindow.cpp
@@ -61,6 +61,14 @@ PreferencesWindow::PreferencesWindow(QWidget *parent) : QvDialog(u"PreferenceWin
         AppConfig.inboundConfig->HasHTTP.ReadWriteBind(httpGroupBox, "checked", &QGroupBox::toggled);
         AppConfig.inboundConfig->HTTPConfig->ListenPort.ReadWriteBind(httpPortLE, "value", &QSpinBox::valueChanged);
         AppConfig.inboundConfig->HTTPConfig->Sniffing.ReadWriteBind(httpSniffingCB, "currentIndex", &QComboBox::currentIndexChanged);
+        AppConfig.inboundConfig->HasHTTP.Observe(
+            [this](auto newVal)
+            {
+                const auto sniffing = AppConfig.inboundConfig->SOCKSConfig->Sniffing;
+                httpOverrideHTTPCB->setEnabled(newVal && sniffing == ProtocolInboundBase::SNIFFING_FULL);
+                httpOverrideTLSCB->setEnabled(newVal && sniffing == ProtocolInboundBase::SNIFFING_FULL);
+                httpOverrideFakeDNSCB->setEnabled(newVal && sniffing != ProtocolInboundBase::SNIFFING_OFF);
+            });
         AppConfig.inboundConfig->HTTPConfig->Sniffing.Observe(
             [this](auto newVal)
             {
@@ -90,6 +98,14 @@ PreferencesWindow::PreferencesWindow(QWidget *parent) : QvDialog(u"PreferenceWin
         AppConfig.inboundConfig->SOCKSConfig->UDPLocalAddress.ReadWriteBind(socksUDPIP, "text", &QLineEdit::textEdited);
 
         AppConfig.inboundConfig->SOCKSConfig->Sniffing.ReadWriteBind(socksSniffingCB, "currentIndex", &QComboBox::currentIndexChanged);
+        AppConfig.inboundConfig->HasSOCKS.Observe(
+            [this](auto newVal)
+            {
+                const auto sniffing = AppConfig.inboundConfig->SOCKSConfig->Sniffing;
+                socksOverrideHTTPCB->setEnabled(newVal && sniffing == ProtocolInboundBase::SNIFFING_FULL);
+                socksOverrideTLSCB->setEnabled(newVal && sniffing == ProtocolInboundBase::SNIFFING_FULL);
+                socksOverrideFakeDNSCB->setEnabled(newVal && sniffing != ProtocolInboundBase::SNIFFING_OFF);
+            });
         AppConfig.inboundConfig->SOCKSConfig->Sniffing.Observe(
             [this](auto newVal)
             {
@@ -115,6 +131,14 @@ PreferencesWindow::PreferencesWindow(QWidget *parent) : QvDialog(u"PreferenceWin
         AppConfig.inboundConfig->DokodemoDoorConfig->ListenPort.ReadWriteBind(tProxyPort, "value", &QSpinBox::valueChanged);
 
         AppConfig.inboundConfig->DokodemoDoorConfig->Sniffing.ReadWriteBind(dokoSniffingCB, "currentIndex", &QComboBox::currentIndexChanged);
+        AppConfig.inboundConfig->HasDokodemoDoor.Observe(
+            [this](auto newVal)
+            {
+                const auto sniffing = AppConfig.inboundConfig->DokodemoDoorConfig->Sniffing;
+                tproxyOverrideHTTPCB->setEnabled(newVal && sniffing == ProtocolInboundBase::SNIFFING_FULL);
+                tproxyOverrideTLSCB->setEnabled(newVal && sniffing == ProtocolInboundBase::SNIFFING_FULL);
+                tproxyOverrideFakeDNSCB->setEnabled(newVal && sniffing != ProtocolInboundBase::SNIFFING_OFF);
+            });
         AppConfig.inboundConfig->DokodemoDoorConfig->Sniffing.Observe(
             [this](auto newVal)
             {


### PR DESCRIPTION
For "Fix Socks5 UDP Associate local address null value": when `"ip"` not provided and when `"ip": ""`, UDP behavior differs
For "Fix FakeDnsObject generation": v2fly/v2ray-core@a21e4a7
For "Fix Trojan sharelink": Qv2ray/QvPlugin-Trojan#18